### PR TITLE
fix: correctly handle newlines for each data format

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ write_records_to_file("output.json", users)
 
 All text-based formats use UTF-8 encoding.
 
+### Newline Handling
+
+Text-based formats handle newlines according to their respective specifications:
+
+| Format      | Line Ending | Notes                              |
+| ----------- | ----------- | ---------------------------------- |
+| CSV         | `\r\n`      | Uses CRLF per RFC 4180             |
+| JSON        | `\n`        | Uses LF line endings               |
+| JSON Lines  | `\n`        | Uses LF line endings per RFC 7464  |
+| TOML        | Platform    | Uses default TextIOWrapper behavior |
+| YAML        | `\n`        | Uses LF line endings               |
+
 ## API Reference
 
 ### Reading

--- a/README.md
+++ b/README.md
@@ -62,15 +62,18 @@ All text-based formats use UTF-8 encoding.
 
 ### Newline Handling
 
-Text-based formats handle newlines according to their respective specifications:
+All text-based formats handle newlines automatically:
 
-| Format      | Line Ending | Notes                              |
-| ----------- | ----------- | ---------------------------------- |
-| CSV         | `\r\n`      | Uses CRLF per RFC 4180             |
-| JSON        | `\n`        | Uses LF line endings               |
-| JSON Lines  | `\n`        | Uses LF line endings per RFC 7464  |
-| TOML        | Platform    | Uses default TextIOWrapper behavior |
-| YAML        | `\n`        | Uses LF line endings               |
+- **On read**: Any newline style (`\n`, `\r\n`, or `\r`) is accepted and normalized
+- **On write**: Each format uses its appropriate line ending per specification
+
+| Format     | Line Ending | Notes    |
+| ---------- | ----------- | -------- |
+| CSV        | `\r\n`      | RFC 4180 |
+| JSON       | `\n`        |          |
+| JSON Lines | `\n`        | RFC 7464 |
+| TOML       | Platform    |          |
+| YAML       | `\n`        |          |
 
 ## API Reference
 

--- a/src/pydanticio/backends/csv.py
+++ b/src/pydanticio/backends/csv.py
@@ -8,8 +8,7 @@ from ..utils import managed_text_io
 
 
 def read_records[T: BaseModel](reader: BinaryIO, model: type[T]) -> list[T]:
-    # Use newline='' so the csv module can handle newlines correctly
-    with managed_text_io(reader, encoding="utf-8", newline="") as text_reader:
+    with managed_text_io(reader, encoding="utf-8") as text_reader:
         csv_reader = csv.DictReader(text_reader)
         return [model.model_validate(row) for row in csv_reader]
 

--- a/src/pydanticio/backends/csv.py
+++ b/src/pydanticio/backends/csv.py
@@ -1,21 +1,27 @@
 import csv
 from collections.abc import Iterable
-from typing import TextIO
+from typing import BinaryIO
 
 from pydantic import BaseModel
 
-
-def read_records[T: BaseModel](reader: TextIO, model: type[T]) -> list[T]:
-    csv_reader = csv.DictReader(reader)
-    return [model.model_validate(row) for row in csv_reader]
+from ..utils import managed_text_io
 
 
-def write_records(writer: TextIO, records: Iterable[BaseModel]) -> None:
-    it = iter(records)
-    first_record = next(it)
-    fields = list(type(first_record).model_fields.keys())
-    csv_writer = csv.DictWriter(writer, fieldnames=fields)
-    csv_writer.writeheader()
-    csv_writer.writerow(first_record.model_dump(mode="json"))
-    for record in it:
-        csv_writer.writerow(record.model_dump(mode="json"))
+def read_records[T: BaseModel](reader: BinaryIO, model: type[T]) -> list[T]:
+    # Use newline='' so the csv module can handle newlines correctly
+    with managed_text_io(reader, encoding="utf-8", newline="") as text_reader:
+        csv_reader = csv.DictReader(text_reader)
+        return [model.model_validate(row) for row in csv_reader]
+
+
+def write_records(writer: BinaryIO, records: Iterable[BaseModel]) -> None:
+    # Use newline='' so the csv module doesn't insert extra blank lines on Windows
+    with managed_text_io(writer, encoding="utf-8", newline="") as text_writer:
+        it = iter(records)
+        first_record = next(it)
+        fields = list(type(first_record).model_fields.keys())
+        csv_writer = csv.DictWriter(text_writer, fieldnames=fields, lineterminator="\r\n")
+        csv_writer.writeheader()
+        csv_writer.writerow(first_record.model_dump(mode="json"))
+        for record in it:
+            csv_writer.writerow(record.model_dump(mode="json"))

--- a/src/pydanticio/backends/json.py
+++ b/src/pydanticio/backends/json.py
@@ -12,5 +12,5 @@ def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
 
 
 def write_record(writer: BinaryIO, record: BaseModel) -> None:
-    with managed_text_io(writer, encoding="utf-8", newline="\n") as text_writer:
+    with managed_text_io(writer, encoding="utf-8", newline="") as text_writer:
         text_writer.write(record.model_dump_json())

--- a/src/pydanticio/backends/json.py
+++ b/src/pydanticio/backends/json.py
@@ -1,12 +1,16 @@
-from typing import TextIO
+from typing import BinaryIO
 
 from pydantic import BaseModel
 
-
-def read_record[T: BaseModel](reader: TextIO, model: type[T]) -> T:
-    data = reader.read()
-    return model.model_validate_json(data)
+from ..utils import managed_text_io
 
 
-def write_record(writer: TextIO, record: BaseModel) -> None:
-    writer.write(record.model_dump_json())
+def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
+    with managed_text_io(reader, encoding="utf-8", newline="\n") as text_reader:
+        data = text_reader.read()
+        return model.model_validate_json(data)
+
+
+def write_record(writer: BinaryIO, record: BaseModel) -> None:
+    with managed_text_io(writer, encoding="utf-8", newline="\n") as text_writer:
+        text_writer.write(record.model_dump_json())

--- a/src/pydanticio/backends/json.py
+++ b/src/pydanticio/backends/json.py
@@ -6,7 +6,7 @@ from ..utils import managed_text_io
 
 
 def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
-    with managed_text_io(reader, encoding="utf-8", newline="\n") as text_reader:
+    with managed_text_io(reader, encoding="utf-8") as text_reader:
         data = text_reader.read()
         return model.model_validate_json(data)
 

--- a/src/pydanticio/backends/json_lines.py
+++ b/src/pydanticio/backends/json_lines.py
@@ -12,7 +12,7 @@ def read_records[T: BaseModel](reader: BinaryIO, model: type[T]) -> list[T]:
 
 
 def write_records(writer: BinaryIO, records: Iterable[BaseModel]) -> None:
-    with managed_text_io(writer, encoding="utf-8") as text_writer:
+    with managed_text_io(writer, encoding="utf-8", newline="\n") as text_writer:
         for record in records:
             text_writer.write(record.model_dump_json())
             text_writer.write("\n")

--- a/src/pydanticio/backends/json_lines.py
+++ b/src/pydanticio/backends/json_lines.py
@@ -12,7 +12,7 @@ def read_records[T: BaseModel](reader: BinaryIO, model: type[T]) -> list[T]:
 
 
 def write_records(writer: BinaryIO, records: Iterable[BaseModel]) -> None:
-    with managed_text_io(writer, encoding="utf-8", newline="\n") as text_writer:
+    with managed_text_io(writer, encoding="utf-8", newline="") as text_writer:
         for record in records:
             text_writer.write(record.model_dump_json())
             text_writer.write("\n")

--- a/src/pydanticio/backends/json_lines.py
+++ b/src/pydanticio/backends/json_lines.py
@@ -1,14 +1,18 @@
 from collections.abc import Iterable
-from typing import TextIO
+from typing import BinaryIO
 
 from pydantic import BaseModel
 
-
-def read_records[T: BaseModel](reader: TextIO, model: type[T]) -> list[T]:
-    return [model.model_validate_json(line) for line in reader]
+from ..utils import managed_text_io
 
 
-def write_records(writer: TextIO, records: Iterable[BaseModel]) -> None:
-    for record in records:
-        writer.write(record.model_dump_json())
-        writer.write("\n")
+def read_records[T: BaseModel](reader: BinaryIO, model: type[T]) -> list[T]:
+    with managed_text_io(reader, encoding="utf-8") as text_reader:
+        return [model.model_validate_json(line) for line in text_reader]
+
+
+def write_records(writer: BinaryIO, records: Iterable[BaseModel]) -> None:
+    with managed_text_io(writer, encoding="utf-8") as text_writer:
+        for record in records:
+            text_writer.write(record.model_dump_json())
+            text_writer.write("\n")

--- a/src/pydanticio/backends/toml.py
+++ b/src/pydanticio/backends/toml.py
@@ -1,13 +1,19 @@
-from typing import TextIO
+from typing import BinaryIO
 
 import tomlkit
 from pydantic import BaseModel
 
-
-def read_record[T: BaseModel](reader: TextIO, model: type[T]) -> T:
-    data = tomlkit.load(reader)
-    return model.model_validate(data)
+from ..utils import managed_text_io
 
 
-def write_record(writer: TextIO, record: BaseModel) -> None:
-    tomlkit.dump(record.model_dump(mode="json"), writer)
+def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
+    # Use newline='\n' to normalize to LF when reading textual formats
+    with managed_text_io(reader, encoding="utf-8", newline="") as text_reader:
+        data = tomlkit.load(text_reader)
+        return model.model_validate(data)
+
+
+def write_record(writer: BinaryIO, record: BaseModel) -> None:
+    # Use newline='\n' so output uses LF line endings regardless of platform
+    with managed_text_io(writer, encoding="utf-8", newline="") as text_writer:
+        tomlkit.dump(record.model_dump(mode="json"), text_writer)

--- a/src/pydanticio/backends/toml.py
+++ b/src/pydanticio/backends/toml.py
@@ -13,6 +13,6 @@ def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
 
 
 def write_record(writer: BinaryIO, record: BaseModel) -> None:
-    # Use newline='\n' so output uses LF line endings regardless of platform
+    # Use platform-specific newline to ensure compatibility
     with managed_text_io(writer, encoding="utf-8", newline=PLATFORM_NEWLINE) as text_writer:
         tomlkit.dump(record.model_dump(mode="json"), text_writer)

--- a/src/pydanticio/backends/toml.py
+++ b/src/pydanticio/backends/toml.py
@@ -7,8 +7,7 @@ from ..utils import managed_text_io
 
 
 def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
-    # Use newline='\n' to normalize to LF when reading textual formats
-    with managed_text_io(reader, encoding="utf-8", newline="") as text_reader:
+    with managed_text_io(reader, encoding="utf-8") as text_reader:
         data = tomlkit.load(text_reader)
         return model.model_validate(data)
 

--- a/src/pydanticio/backends/toml.py
+++ b/src/pydanticio/backends/toml.py
@@ -3,7 +3,7 @@ from typing import BinaryIO
 import tomlkit
 from pydantic import BaseModel
 
-from ..utils import managed_text_io
+from ..utils import PLATFORM_NEWLINE, managed_text_io
 
 
 def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
@@ -14,5 +14,5 @@ def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
 
 def write_record(writer: BinaryIO, record: BaseModel) -> None:
     # Use newline='\n' so output uses LF line endings regardless of platform
-    with managed_text_io(writer, encoding="utf-8", newline="") as text_writer:
+    with managed_text_io(writer, encoding="utf-8", newline=PLATFORM_NEWLINE) as text_writer:
         tomlkit.dump(record.model_dump(mode="json"), text_writer)

--- a/src/pydanticio/backends/toml_stub.py
+++ b/src/pydanticio/backends/toml_stub.py
@@ -1,11 +1,11 @@
-from typing import TextIO
+from typing import BinaryIO
 
 from pydantic import BaseModel
 
 
-def read_record[T: BaseModel](reader: TextIO, model: type[T]) -> T:
+def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
     raise NotImplementedError("toml backend is not available.")
 
 
-def write_record(writer: TextIO, record: BaseModel) -> None:
+def write_record(writer: BinaryIO, record: BaseModel) -> None:
     raise NotImplementedError("toml backend is not available.")

--- a/src/pydanticio/backends/yaml.py
+++ b/src/pydanticio/backends/yaml.py
@@ -1,13 +1,17 @@
-from typing import TextIO
+from typing import BinaryIO
 
 import yaml
 from pydantic import BaseModel
 
-
-def read_record[T: BaseModel](reader: TextIO, model: type[T]) -> T:
-    data = yaml.safe_load(reader)
-    return model.model_validate(data)
+from ..utils import managed_text_io
 
 
-def write_record(writer: TextIO, record: BaseModel) -> None:
-    yaml.safe_dump(record.model_dump(mode="json"), writer, line_break="\n")
+def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
+    with managed_text_io(reader, encoding="utf-8", newline="\n") as text_reader:
+        data = yaml.safe_load(text_reader)
+        return model.model_validate(data)
+
+
+def write_record(writer: BinaryIO, record: BaseModel) -> None:
+    with managed_text_io(writer, encoding="utf-8", newline="\n") as text_writer:
+        yaml.safe_dump(record.model_dump(mode="json"), text_writer, line_break="\n")

--- a/src/pydanticio/backends/yaml.py
+++ b/src/pydanticio/backends/yaml.py
@@ -7,7 +7,7 @@ from ..utils import managed_text_io
 
 
 def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
-    with managed_text_io(reader, encoding="utf-8", newline="\n") as text_reader:
+    with managed_text_io(reader, encoding="utf-8") as text_reader:
         data = yaml.safe_load(text_reader)
         return model.model_validate(data)
 

--- a/src/pydanticio/backends/yaml.py
+++ b/src/pydanticio/backends/yaml.py
@@ -13,5 +13,5 @@ def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
 
 
 def write_record(writer: BinaryIO, record: BaseModel) -> None:
-    with managed_text_io(writer, encoding="utf-8", newline="\n") as text_writer:
+    with managed_text_io(writer, encoding="utf-8", newline="") as text_writer:
         yaml.safe_dump(record.model_dump(mode="json"), text_writer, line_break="\n")

--- a/src/pydanticio/backends/yaml_stub.py
+++ b/src/pydanticio/backends/yaml_stub.py
@@ -1,11 +1,11 @@
-from typing import TextIO
+from typing import BinaryIO
 
 from pydantic import BaseModel
 
 
-def read_record[T: BaseModel](reader: TextIO, model: type[T]) -> T:
+def read_record[T: BaseModel](reader: BinaryIO, model: type[T]) -> T:
     raise NotImplementedError("yaml backend is not available.")
 
 
-def write_record(writer: TextIO, record: BaseModel) -> None:
+def write_record(writer: BinaryIO, record: BaseModel) -> None:
     raise NotImplementedError("yaml backend is not available.")

--- a/src/pydanticio/utils.py
+++ b/src/pydanticio/utils.py
@@ -1,0 +1,13 @@
+from contextlib import contextmanager
+from io import TextIOWrapper
+from typing import BinaryIO
+
+
+@contextmanager
+def managed_text_io(binary_io: BinaryIO, encoding: str = "utf-8", newline: str | None = None):
+    wrapper = TextIOWrapper(binary_io, encoding=encoding, newline=newline)
+    try:
+        yield wrapper
+    finally:
+        if not wrapper.closed:
+            wrapper.detach()

--- a/src/pydanticio/utils.py
+++ b/src/pydanticio/utils.py
@@ -1,6 +1,9 @@
+import os
 from contextlib import contextmanager
 from io import TextIOWrapper
 from typing import BinaryIO
+
+PLATFORM_NEWLINE = "\r\n" if os.name == "nt" else "\n"
 
 
 @contextmanager

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,6 @@
 import os
 from pydantic import BaseModel, ConfigDict
 
-PLATFORM_NEWLINE = "\r\n" if os.name == "nt" else "\n"
-
 
 class SampleRecord(BaseModel):
     model_config = ConfigDict(frozen=True)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -6,12 +6,15 @@ from pydanticio import read_records_from_reader, write_records_to_writer
 from . import SampleRecord, test_records
 
 
-records_str = "\r\n".join(
-    [
-        test_records[0].get_csv_header(),
-        test_records[0].to_csv_row(),
-        test_records[1].to_csv_row(),
-    ]
+records_str = (
+    "\r\n".join(
+        [
+            test_records[0].get_csv_header(),
+            test_records[0].to_csv_row(),
+            test_records[1].to_csv_row(),
+        ]
+    )
+    + "\r\n"
 )
 
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -3,10 +3,10 @@ from io import BytesIO
 
 from pydanticio import read_records_from_reader, write_records_to_writer
 
-from . import SampleRecord, test_records, PLATFORM_NEWLINE
+from . import SampleRecord, test_records
 
 
-records_str = PLATFORM_NEWLINE.join(
+records_str = "\r\n".join(
     [
         test_records[0].get_csv_header(),
         test_records[0].to_csv_row(),

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -4,6 +4,7 @@ from pydanticio import (
     read_record_from_reader,
     write_record_to_writer,
 )
+from pydanticio.utils import PLATFORM_NEWLINE
 import tomlkit
 
 from . import SampleRecord, test_records
@@ -17,7 +18,9 @@ def test_read_record_from_reader():
 
 
 def test_write_record_to_writer():
-    data = tomlkit.dumps(test_records[0].model_dump()).encode("utf-8")
+    data = tomlkit.dumps(test_records[0].model_dump())
     writer = BytesIO()
     write_record_to_writer(writer, test_records[0], "toml")
-    assert writer.getvalue() == data
+    written_data = writer.getvalue().decode("utf-8")
+    assert written_data.strip().replace("\r\n", "\n") == data.strip()
+    assert written_data.endswith(PLATFORM_NEWLINE)


### PR DESCRIPTION
closes #21 
closes #24 

This pull request refactors the handling of text and binary IO throughout the codebase to ensure consistent newline and encoding handling across all supported data formats. It introduces a new utility, `managed_text_io`, to wrap binary streams as text streams with the appropriate encoding and newline behavior. The changes also standardize the backend APIs to use `BinaryIO` instead of `TextIO`, and clarify newline handling in the documentation.

**IO and newline handling improvements:**

* Added `managed_text_io` context manager and `PLATFORM_NEWLINE` constant in `utils.py` to standardize text IO wrapping and platform-specific newline handling. (`src/pydanticio/utils.py`)
* Updated all backend modules (`csv.py`, `json.py`, `json_lines.py`, `toml.py`, `yaml.py`, and their stubs) to use `BinaryIO` for their APIs and to wrap streams using `managed_text_io`, ensuring consistent encoding and newline behavior. (`src/pydanticio/backends/csv.py`, `src/pydanticio/backends/json.py`, `src/pydanticio/backends/json_lines.py`, `src/pydanticio/backends/toml.py`, `src/pydanticio/backends/toml_stub.py`, `src/pydanticio/backends/yaml.py`, `src/pydanticio/backends/yaml_stub.py`) [[1]](diffhunk://#diff-db1f9c4d06c0215388c63f944172977733261b377f8f740a32f4d0bf22d49f62L3-R22) [[2]](diffhunk://#diff-cb78931989fe3f123af9f94eab78afa6ddb17b4fa06da5082e4af27334fd4724L1-R16) [[3]](diffhunk://#diff-6005e7a30d482dd0d90d36970d73d21f0103de8154bb83e3f2394c5dc428c19fL2-R18) [[4]](diffhunk://#diff-65eae4dabf372339c9b8f5e6917eb8c5eee59220f9d75ac7829740c8b4586c14L1-R18) [[5]](diffhunk://#diff-8cd986a4d89b1f53a269b8850220aeb6d9b8e78d10de87dbe1847b2eb3f1b59bL1-R10) [[6]](diffhunk://#diff-eb2b8e46ebc1c12cf74fa95d0152a46698e5d2e9f9adfe6013b5826f474ebaa2L1-R17) [[7]](diffhunk://#diff-30e95314edc2d39988e7527965948f2ec050cfd2f831265ded4019ee7b4e83eaL1-R10)
* Removed the old `detach_on_exit` context manager and replaced its usage with `managed_text_io` throughout the main API in `__init__.py`. All read/write functions now operate directly on `BinaryIO` and delegate text wrapping to the backends. (`src/pydanticio/__init__.py`) [[1]](diffhunk://#diff-9bf932e51075c4388476862472427d745d6e0ee07f76246f8beec1038d55574fL2-L3) [[2]](diffhunk://#diff-9bf932e51075c4388476862472427d745d6e0ee07f76246f8beec1038d55574fL35-L43) [[3]](diffhunk://#diff-9bf932e51075c4388476862472427d745d6e0ee07f76246f8beec1038d55574fL67-R62) [[4]](diffhunk://#diff-9bf932e51075c4388476862472427d745d6e0ee07f76246f8beec1038d55574fL108-R98) [[5]](diffhunk://#diff-9bf932e51075c4388476862472427d745d6e0ee07f76246f8beec1038d55574fL148-R129) [[6]](diffhunk://#diff-9bf932e51075c4388476862472427d745d6e0ee07f76246f8beec1038d55574fL190-R166)

**Documentation and test updates:**

* Added a section to the `README.md` documenting newline handling for all supported formats, specifying which line endings are used for each. (`README.md`)
* Updated tests to use the new `PLATFORM_NEWLINE` from `pydanticio.utils` and improved assertions to account for platform-specific line endings. (`tests/test_csv.py`, `tests/test_toml.py`, `tests/__init__.py`) [[1]](diffhunk://#diff-8789098ed2a3a26eb03a72c01b6432558382e227eb4cc9bc3cbd50f570f9857bL6-R9) [[2]](diffhunk://#diff-5fa5d2b4af01042326a2f9882927627820fe23217dcff64c970f1d927efb6fa7R7) [[3]](diffhunk://#diff-5fa5d2b4af01042326a2f9882927627820fe23217dcff64c970f1d927efb6fa7L20-R26) [[4]](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dL4-L5)